### PR TITLE
Daden/fix bert senteval

### DIFF
--- a/examples/sentence_similarity/bert_senteval.ipynb
+++ b/examples/sentence_similarity/bert_senteval.ipynb
@@ -177,9 +177,8 @@
    "source": [
     "data_path = os.path.join(LOCAL_SENTEVAL, \"data/downstream\")\n",
     "data_script = \"get_transfer_data.bash\"\n",
-    "\n",
-    "if not any([f.is_dir() for f in os.scandir(data_path)]):\n",
-    "    !cd $data_path && ./$data_script"
+    "tokenizer_name = \"tokenizer.sed\"\n",
+    "!cd $data_path && pwd  && chmod 777 $data_script && chmod 777 $tokenizer_name &&bash $data_script"
    ]
   },
   {
@@ -522,6 +521,7 @@
     "            \"scikit-learn==0.20.3\",\n",
     "            \"azureml-sdk==1.0.53\",\n",
     "            \"pytorch-pretrained-bert>=0.6\",\n",
+    "            \"cached-property==1.5.1\",\n",
     "        ],\n",
     "    )\n",
     "\n",

--- a/utils_nlp/azureml/azureml_utils.py
+++ b/utils_nlp/azureml/azureml_utils.py
@@ -124,7 +124,7 @@ def get_or_create_amlcompute(
             max_nodes=max_nodes,
             idle_seconds_before_scaledown=idle_seconds_before_scaledown,
         )
-        compute_target = ComputeTarget.create(ws, compute_name, compute_config)
+        compute_target = ComputeTarget.create(workspace, compute_name, compute_config)
         compute_target.wait_for_completion(show_output=verbose)
 
     return compute_target

--- a/utils_nlp/eval/SentEval/data/downstream/get_transfer_data.bash
+++ b/utils_nlp/eval/SentEval/data/downstream/get_transfer_data.bash
@@ -1,0 +1,104 @@
+# Copyright (c) 2017-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
+#
+
+#
+# Download and tokenize data with MOSES tokenizer
+#
+
+
+""" adapted the original script to only download the STSBenchmark data"""
+data_path=.
+preprocess_exec=./tokenizer.sed
+
+# Get MOSES
+echo 'Cloning Moses github repository (for tokenization scripts)...'
+git clone https://github.com/moses-smt/mosesdecoder.git
+SCRIPTS=mosesdecoder/scripts
+MTOKENIZER=$SCRIPTS/tokenizer/tokenizer.perl
+LOWER=$SCRIPTS/tokenizer/lowercase.perl
+
+if [ ! -d "$SCRIPTS" ]; then
+    echo "Please set SCRIPTS variable correctly to point to Moses scripts."
+    exit
+fi
+
+PTBTOKENIZER="sed -f tokenizer.sed"
+
+mkdir $data_path
+
+STSBenchmark='http://ixa2.si.ehu.es/stswiki/images/4/48/Stsbenchmark.tar.gz'
+
+
+# STS 2012, 2013, 2014, 2015, 2016
+declare -A STS_tasks
+declare -A STS_paths
+declare -A STS_subdirs
+
+STS_tasks=(["STS12"]="MSRpar MSRvid SMTeuroparl surprise.OnWN surprise.SMTnews" ["STS13"]="FNWN headlines OnWN" ["STS14"]="deft-forum deft-news headlines OnWN images tweet-news" ["STS15"]="answers-forums answers-students belief headlines images" ["STS16"]="answer-answer headlines plagiarism postediting question-question")
+
+STS_paths=(["STS12"]="http://ixa2.si.ehu.es/stswiki/images/4/40/STS2012-en-test.zip" ["STS13"]="http://ixa2.si.ehu.es/stswiki/images/2/2f/STS2013-en-test.zip" ["STS14"]="http://ixa2.si.ehu.es/stswiki/images/8/8c/STS2014-en-test.zip" ["STS15"]="http://ixa2.si.ehu.es/stswiki/images/d/da/STS2015-en-test.zip"
+["STS16"]="http://ixa2.si.ehu.es/stswiki/images/9/98/STS2016-en-test.zip")
+
+STS_subdirs=(["STS12"]="test-gold" ["STS13"]="test-gs" ["STS14"]="sts-en-test-gs-2014" ["STS15"]="test_evaluation_task2a" ["STS16"]="sts2016-english-with-gs-v1.0")
+
+
+
+
+### STS datasets
+
+# STS12, STS13, STS14, STS15, STS16
+mkdir $data_path/STS
+
+for task in "${!STS_tasks[@]}"; #"${!STS_tasks[@]}";
+do
+    fpath=${STS_paths[$task]}
+    echo $fpath
+    curl -Lo $data_path/STS/data_$task.zip $fpath
+    unzip $data_path/STS/data_$task.zip -d $data_path/STS
+    mv $data_path/STS/${STS_subdirs[$task]} $data_path/STS/$task-en-test
+    rm $data_path/STS/data_$task.zip
+
+    for sts_task in ${STS_tasks[$task]}
+    do
+        fname=STS.input.$sts_task.txt
+        task_path=$data_path/STS/$task-en-test/
+
+        if [ "$task" = "STS16" ] ; then
+            echo 'Handling STS2016'
+            mv $task_path/STS2016.input.$sts_task.txt $task_path/$fname
+            mv $task_path/STS2016.gs.$sts_task.txt $task_path/STS.gs.$sts_task.txt
+        fi
+
+
+
+        cut -f1 $task_path/$fname | $MTOKENIZER -threads 8 -l en -no-escape | $LOWER > $task_path/tmp1
+        cut -f2 $task_path/$fname | $MTOKENIZER -threads 8 -l en -no-escape | $LOWER > $task_path/tmp2
+        paste $task_path/tmp1 $task_path/tmp2 > $task_path/$fname
+        rm $task_path/tmp1 $task_path/tmp2
+    done
+
+done
+
+
+# STSBenchmark (http://ixa2.si.ehu.es/stswiki/index.php/STSbenchmark)
+
+curl -Lo $data_path/Stsbenchmark.tar.gz $STSBenchmark
+tar -zxvf $data_path/Stsbenchmark.tar.gz -C $data_path
+rm $data_path/Stsbenchmark.tar.gz
+mv $data_path/stsbenchmark $data_path/STS/STSBenchmark
+
+for split in train dev test
+do
+    fname=sts-$split.csv
+    fdir=$data_path/STS/STSBenchmark
+    cut -f1,2,3,4,5 $fdir/$fname > $fdir/tmp1
+    cut -f6 $fdir/$fname | $MTOKENIZER -threads 8 -l en -no-escape | $LOWER > $fdir/tmp2
+    cut -f7 $fdir/$fname | $MTOKENIZER -threads 8 -l en -no-escape | $LOWER > $fdir/tmp3
+    paste $fdir/tmp1 $fdir/tmp2 $fdir/tmp3 > $fdir/$fname
+    rm $fdir/tmp1 $fdir/tmp2 $fdir/tmp3
+done
+

--- a/utils_nlp/eval/SentEval/data/downstream/tokenizer.sed
+++ b/utils_nlp/eval/SentEval/data/downstream/tokenizer.sed
@@ -1,0 +1,80 @@
+# Sed script to produce Penn Treebank tokenization on arbitrary raw text.
+# Yeah, sure.
+
+# expected input: raw text with ONE SENTENCE TOKEN PER LINE
+
+# by Robert MacIntyre, University of Pennsylvania, late 1995.
+
+# If this wasn't such a trivial program, I'd include all that stuff about
+# no warrantee, free use, etc. from the GNU General Public License.  If you
+# want to be picky, assume that all of its terms apply.  Okay?
+
+# attempt to get correct directional quotes
+s=^"=`` =g
+s=\([ ([{<]\)"=\1 `` =g
+# close quotes handled at end
+
+s=\.\.\.= ... =g
+s=[,;:@#$%&]= & =g
+
+# Assume sentence tokenization has been done first, so split FINAL periods
+# only. 
+s=\([^.]\)\([.]\)\([])}>"']*\)[     ]*$=\1 \2\3 =g
+# however, we may as well split ALL question marks and exclamation points,
+# since they shouldn't have the abbrev.-marker ambiguity problem
+s=[?!]= & =g
+
+# parentheses, brackets, etc.
+s=[][(){}<>]= & =g
+# Some taggers, such as Adwait Ratnaparkhi's MXPOST, use the parsed-file
+# version of these symbols.
+# UNCOMMENT THE FOLLOWING 6 LINES if you're using MXPOST.
+# s/(/-LRB-/g
+# s/)/-RRB-/g
+# s/\[/-LSB-/g
+# s/\]/-RSB-/g
+# s/{/-LCB-/g
+# s/}/-RCB-/g
+
+s=--= -- =g
+
+# NOTE THAT SPLIT WORDS ARE NOT MARKED.  Obviously this isn't great, since
+# you might someday want to know how the words originally fit together --
+# but it's too late to make a better system now, given the millions of
+# words we've already done "wrong".
+
+# First off, add a space to the beginning and end of each line, to reduce
+# necessary number of regexps.
+s=$= =
+s=^= =
+
+s="= '' =g
+# possessive or close-single-quote
+s=\([^']\)' =\1 ' =g
+# as in it's, I'm, we'd
+s='\([sSmMdD]\) = '\1 =g
+s='ll = 'll =g
+s='re = 're =g
+s='ve = 've =g
+s=n't = n't =g
+s='LL = 'LL =g
+s='RE = 'RE =g
+s='VE = 'VE =g
+s=N'T = N'T =g
+
+s= \([Cc]\)annot = \1an not =g
+s= \([Dd]\)'ye = \1' ye =g
+s= \([Gg]\)imme = \1im me =g
+s= \([Gg]\)onna = \1on na =g
+s= \([Gg]\)otta = \1ot ta =g
+s= \([Ll]\)emme = \1em me =g
+s= \([Mm]\)ore'n = \1ore 'n =g
+s= '\([Tt]\)is = '\1 is =g
+s= '\([Tt]\)was = '\1 was =g
+s= \([Ww]\)anna = \1an na =g
+# s= \([Ww]\)haddya = \1ha dd ya =g
+# s= \([Ww]\)hatcha = \1ha t cha =g
+
+# clean out extra spaces
+s=  *= =g
+s=^ *==g


### PR DESCRIPTION
### Description
This pr fixes the issue in notebook  examples/sentence_similarity/bert_senteval.ipynb

1. adapted the original script in SentEval to only download STSbenchmark.
2. added the scripts for data downloading
3. fix the cell in the notebook to download data
4. fix the azureml_utils get_or_create_amlcompute for error "ws is not defined"
5. add python package cached_property for aml run


### Related Issues
https://github.com/microsoft/nlp/issues/369


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



