### PR TITLE
Fix: Set Utils version to default when in dev mode

### DIFF
--- a/utils_nlp/__init__.py
+++ b/utils_nlp/__init__.py
@@ -16,6 +16,13 @@ LICENSE = __license__
 COPYRIGHT = __copyright__
 
 # Determine semantic versioning automatically
-# from git commits
-__version__ = get_version()
+# from git commits if the package is installed
+# into your environment, otherwise
+# we set version to default for development
+try:
+    __version__ = get_version()
+except LookupError:
+    __version__ = "0.0.0"
+
 VERSION = __version__
+


### PR DESCRIPTION


### Description
<!--- Describe your changes in detail -->
Default the version of `utils_nlp` to "0.0.0" when in development mode or when `utils_nlp` is not installed into your environment.  
<!--- Why is this change required? What problem does it solve? -->
Fixes the following issues:

1. Issue when setuptools_scm is not installed
1. Working directly on the `utils_nlp` package and want to use directly without pip installing it locally.


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [x] I have updated the documentation accordingly.



