### PR TITLE
Remove setuptools scm versioning dependencies for now

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -96,13 +96,15 @@ If you are using the DSVM, you can [connect to JupyterHub](https://docs.microsof
     <p>  
 A setup.py file is provided in order to simplify the installation of this utilities in this repo from the main directory.  
     
-To install, please run the command below
+To install the package, please run the command below (from directory root)
 
-    python setup.py install 
+    pip install -e . 
 
-It is also possible to install directly from Github, which is the best way to utilize the `utils_nlp` package in external projects. 
+Running the command tells pip to install the `utils_nlp` package from source in [development mode](https://setuptools.readthedocs.io/en/latest/setuptools.html#development-mode). This just means that any updates to `utils_nlp` source directory will immediately be reflected in the installed package without needing to reinstall; a very useful practice for a package with constant updates.   
 
-    pip install -e  git+git@github.com:microsoft/nlp.git@master#egg=utils_nlp  
+> It is also possible to install directly from Github, which is the best way to utilize the `utils_nlp` package in external projects (while still reflecting updates to the source as it's installed as an editable `'-e'` package). 
+
+>   `pip install -e  git+git@github.com:microsoft/nlp.git@master#egg=utils_nlp`  
 
 Either command, from above, makes `utils_nlp` available in your conda virtual environment. You can verify it was properly installed by running:  
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,9 +1,10 @@
 # Semantic Versioning
+> NOTE: Support for `setuptools_scm` is currently removed due to a known [issue](https://github.com/pypa/setuptools_scm/issues/357) with the way pip installations restrict access to certain SCM metadata during package installation. Support will be restored when `setuptools_scm` and `pip` developers fix this with a patch.
 
 This library is configured to use
 [setuptools_scm](https://github.com/pypa/setuptools_scm/) to automatically get package version from git commit histories.
 
-> NOTE: **There shouldn't be any references to manually coded versions**.
+**There shouldn't be any references to manually coded versions**.
 
 Verify what git tag to use by running:
 

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ setup(
     },
     keywords=["Microsoft NLP", "Natural Language Processing", "Text Processing", "Word Embedding"],
     python_requires=">=3.6",
-    install_requires=["setuptools_scm>=3.2.0"],
+    install_requires=[],
     dependency_links=[],
     extras_require={},
-    use_scm_version={"root": ".", "relative_to": __file__},
-    setup_requires=["setuptools_scm"],
+    use_scm_version=False,
+    setup_requires=[],
 )

--- a/tools/generate_conda_file.py
+++ b/tools/generate_conda_file.py
@@ -75,7 +75,6 @@ PIP_BASE = {
     "pre-commit": "pre-commit>=1.14.4",
     "scikit-learn": "scikit-learn>=0.19.0,<=0.20.3",
     "seaborn": "seaborn>=0.9.0",
-    "setuptools_scm": "setuptools_scm==3.2.0",
     "sklearn-crfsuite": "sklearn-crfsuite>=0.3.6",
     "spacy": "spacy>=2.1.4",
     "spacy-models": (

--- a/utils_nlp/__init__.py
+++ b/utils_nlp/__init__.py
@@ -1,28 +1,16 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-from setuptools_scm import get_version
-
-
 __title__ = "Microsoft NLP"
 __author__ = "AI CAT at Microsoft"
 __license__ = "MIT"
 __copyright__ = "Copyright 2018-present Microsoft Corporation"
+__version__ = "1.0.0"
 
 # Synonyms
 TITLE = __title__
 AUTHOR = __author__
 LICENSE = __license__
 COPYRIGHT = __copyright__
-
-# Determine semantic versioning automatically
-# from git commits if the package is installed
-# into your environment, otherwise
-# we set version to default for development
-try:
-    __version__ = get_version()
-except LookupError:
-    __version__ = "0.0.0"
-
 VERSION = __version__
 


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
**This PR does the following:**  
1. Remove setuptools_scm dependencies due to permission issues with pip and scm. pip fails to provide a nice way for setuptools_scm to get access to the temporary scm metadata files it creates when installing the package.
2. Add instruction that removes the need to update pip if any changes are made to utils package.
3. Document the known issue with setuptools_scm and pip that fails to give setuptools_scm permission to scm metadata files.  
1. Temporarily removes the dependency on `setuptools_scm` for automatic versioning because of none issue with pip. Issue on setuptool_scm site is [here](https://github.com/pypa/setuptools_scm/issues/357) 

<!--- Why is this change required? What problem does it solve? -->  
**These changes are needed because it:**
Address the issue experienced by developers when working on the `utils_nlp` package in development mode. Currently, versioning has to be done manually as we also took out support for `setuptools_scm`. We'll revisit adding support for automatic versioning when issue is resolved between `setuptools_scm` and `pip` developers.


### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [x] I have updated the documentation accordingly.



