### PR TITLE
Fixed deprecation warnings

### DIFF
--- a/utils_nlp/dataset/multinli.py
+++ b/utils_nlp/dataset/multinli.py
@@ -53,7 +53,6 @@ def get_generator(
             One of: {"train", "dev_matched", "dev_mismatched"}
             Defaults to "train".
         block_size (int, optional): Size of partition in bytes.
-        random_seed (int, optional): Random seed. See random.seed().Defaults to None.
         num_batches (int): Number of batches to generate.
         batch_size (int]): Batch size.
     Returns:

--- a/utils_nlp/eval/SentEval/senteval/utils.py
+++ b/utils_nlp/eval/SentEval/senteval/utils.py
@@ -86,7 +86,7 @@ def get_optimizer(s):
         raise Exception('Unknown optimization method: "%s"' % method)
 
     # check that we give good parameters to the optimizer
-    expected_args = inspect.getargspec(optim_fn.__init__)[0]
+    expected_args = inspect.getfullargspec(optim_fn.__init__)[0]
     assert expected_args[:2] == ['self', 'params']
     if not all(k in expected_args[2:] for k in optim_params.keys()):
         raise Exception('Unexpected parameters: expected "%s", got "%s"' % (

--- a/utils_nlp/interpreter/Interpreter.py
+++ b/utils_nlp/interpreter/Interpreter.py
@@ -15,15 +15,11 @@ def calculate_regularization(sampled_x, Phi, reduced_axes=None, device=None):
     """ Calculate the variance that is used for Interpreter
 
     Args:
-        sample_x (list of torch.FloatTensor):
+        sampled_x (list of torch.FloatTensor):
             A list of sampled input embeddings $x$, each $x$ is of shape
             ``[length, dimension]``. All the $x$s can have different length,
             but should have the same dimension. Sampled number should be
             higher to get a good estimation.
-        Phi (function):
-            The $Phi$ we studied. A function whose input is x (element in
-            the first parameter) and returns a hidden state (of type
-            ``torch.FloatTensor``, of any shape)
         reduced_axes (list of ints, Optional):
             The axes that is variable in Phi (e.g., the sentence length axis).
             We will reduce these axes by mean along them.

--- a/utils_nlp/models/bert/common.py
+++ b/utils_nlp/models/bert/common.py
@@ -10,7 +10,7 @@ import csv
 import linecache
 import subprocess
 import warnings
-from collections import Iterable
+from collections.abc import Iterable
 from enum import Enum
 
 import torch

--- a/utils_nlp/models/bert/sequence_encoding.py
+++ b/utils_nlp/models/bert/sequence_encoding.py
@@ -161,8 +161,7 @@ class BERTSentenceEncoder:
         
         Args:
             df: pd.DataFrame with columns text_index (int), token (str), layer_index (int), values (list[float])
-            pooling_strategy: The pooling strategy to use
-        
+
         Returns:
             pd.DataFrame grouped by text index and layer index
         """


### PR DESCRIPTION
### Description

Fixed some deprecation warnings:

* importing `Iterable` directly from `collections` has been deprecated since python 3.3. It should be imported from `collections.abc` instead. [[source]](https://docs.python.org/3.8/library/collections.html)
* `inspect.getargspec` has been deprecated since python 3.0, and should be replaced with `inspect.getfullargspec` [[source]](https://docs.python.org/3/library/inspect.html#inspect.getargspec)

Other:

* removed docstrings for non-existing parameters


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



