### PR TITLE
Hlu/remove pytorch transformers from cgmanifest

### DIFF
--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -3,16 +3,6 @@
       "component": { 
        "type": "git", 
        "git": { 
-         "repositoryUrl": "https://github.com/huggingface/pytorch-transformers", 
-         "commitHash": "b33a385091de604afb566155ec03329b84c96926" 
-         }
-       },
-       "license": "Apache-2.0"
-    },
-    {
-      "component": { 
-       "type": "git", 
-       "git": { 
          "repositoryUrl": "https://github.com/allenai/bi-att-flow", 
          "commitHash": "e444acf13892cf62189b9eac3c7654bd83baf848" 
          }


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Remove pytorch-transformers from cgmanifest because it's now included in generate_conda_file

### Related Issues
<!--- If it fixes an open issue, please link to the issue here. -->


### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project, as detailed in our [contribution guidelines](../CONTRIBUTING.md).
- [ ] I have added tests.
- [ ] I have updated the documentation accordingly.



